### PR TITLE
Add word count validation for posts

### DIFF
--- a/.github/workflows/xpost.yaml
+++ b/.github/workflows/xpost.yaml
@@ -23,8 +23,14 @@ jobs:
       - name: Print Output Tweet
         id: output-tweet
         run: echo "${{ steps.notion-post-fetcher.outputs.tweet }}"
+      - name: Validate word count
+        id: validate-word-count
+        run: |
+          echo "${{ steps.notion-post-fetcher.outputs.tweet }}" > tweet.txt
+          ./scripts/validate_word_count.sh tweet.txt
       - name: Post tweet
         id: tweetx
+        if: success()
         uses: raycast-jp/post-tweet-v2-action@v0.0.3
         with:
           message: ${{ steps.notion-post-fetcher.outputs.tweet }}
@@ -56,6 +62,6 @@ jobs:
         uses: slackapi/slack-github-action@v1.27.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          slack-message: "投稿に失敗しました。エラー内容を確認してください: ${{ steps.tweetx.outputs.postFailed }} \n 実行結果の詳細はこちら: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "投稿に失敗しました。エラー内容を確認してください: ${{ steps.tweetx.outputs.postFailed }} \n �実行結果の詳細はこちら: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ Automate operations of the community
 ## X post automate(planned)
 * GitHub Actionsで定期的にNotionDBを監視する
 * NotionDBに当日に投稿すべき内容があれば投稿を行う
+* 投稿の文字数が200文字を超える場合、エラーが発生し、Slackで通知されます。

--- a/scripts/validate_word_count.sh
+++ b/scripts/validate_word_count.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Validate the word count of the post
+# Usage: ./validate_word_count.sh <file>
+
+FILE=$1
+
+if [ ! -f "$FILE" ]; then
+  echo "File not found!"
+  exit 1
+fi
+
+WORD_COUNT=$(wc -m < "$FILE")
+
+if [ "$WORD_COUNT" -gt 200 ]; then
+  echo "Word count exceeds 200 characters!"
+  exit 1
+fi
+
+echo "Word count is within the limit."
+exit 0


### PR DESCRIPTION
Fixes #6

Add validation for word count in post workflow.

* Modify `README.md` to include a note about the new validation step for word count and mention the word count limit of 200 characters for posts.
* Modify `.github/workflows/xpost.yaml` to add a new step before the `Post tweet` step to validate the word count using a shell script. If the word count exceeds 200 characters, set a failure status and trigger the `Notify error via slack` step.
* Add `scripts/validate_word_count.sh` to create a new shell script to validate the word count of the post. Check if the word count exceeds 200 characters and exit with a non-zero status if it does.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/raycast-jp/automate-operations/issues/6?shareId=0054d40c-ab0e-4980-92f6-ef56bad571a6).