### PR TITLE
chore: update post-tweet-v2-action to v0.1.0

### DIFF
--- a/.github/workflows/xpost.yaml
+++ b/.github/workflows/xpost.yaml
@@ -30,10 +30,10 @@ jobs:
           echo "Tweet Media: ${{ fromJson(steps.notion-post-fetcher.outputs.tweet).media }}"
       - name: Post tweet
         id: tweetx
-        uses: raycast-jp/post-tweet-v2-action@v0.0.9
+        uses: raycast-jp/post-tweet-v2-action@v0.1.0
         with:
           message: ${{ fromJson(steps.notion-post-fetcher.outputs.tweet).content }}
-          image: ${{ fromJson(steps.notion-post-fetcher.outputs.tweet).media }}
+          media: ${{ fromJson(steps.notion-post-fetcher.outputs.tweet).media }}
           consumer-key: ${{ secrets.TWITTER_CONSUMER_KEY }}
           consumer-secret: ${{ secrets.TWITTER_CONSUMER_SECRET }}
           access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- `raycast-jp/post-tweet-v2-action` を `v0.0.9` → `v0.1.0` に更新
- Breaking Change 対応: input パラメータ `image` → `media` にリネーム
- v0.1.0 で動画(MP4, MOV)・GIF アップロードに対応

## Reference
- https://github.com/raycast-jp/post-tweet-v2-action/releases/tag/v0.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)