### PR TITLE
fix: migrate slack-github-action inputs from v1 to v2 API

### DIFF
--- a/.github/workflows/xpost.yaml
+++ b/.github/workflows/xpost.yaml
@@ -45,23 +45,21 @@ jobs:
         id: slack
         uses: slackapi/slack-github-action@v2.1.1
         with:
-          # Slack channel id, channel name, or user id to post message.
-          # See also: https://api.slack.com/methods/chat.postMessage#channels
-          # You can pass in multiple channels to post to by providing a comma-delimited list of channel IDs.
-          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          # For posting a simple plain text message
-          slack-message: "只今ツイートしましたのでいいね、リツイートなどリアクションお願いします！！\nhttps://x.com/Raycast0731/status/${{ steps.tweetx.outputs.tweetID }}"
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "只今ツイートしましたのでいいね、リツイートなどリアクションお願いします！！\nhttps://x.com/Raycast0731/status/${{ steps.tweetx.outputs.tweetID }}"
       # Use the output from the `hello` step
       - name: Get the output time
         run: echo "it was succeeded on ${{ steps.hello.outputs.time }}"
       - name: Notify error via slack
-        if: failure() 
+        if: failure()
         id: error-notifier
         uses: slackapi/slack-github-action@v2.1.1
         with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          slack-message: "投稿に失敗しました。エラー内容を確認してください: ${{ steps.tweetx.outputs.postFailed }} \n 実行結果の詳細はこちら: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "投稿に失敗しました。エラー内容を確認してください: ${{ steps.tweetx.outputs.postFailed }} \n 実行結果の詳細はこちら: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Summary

`slackapi/slack-github-action` が Dependabot により v1.27.0 → v2.1.1 にアップデートされましたが、v2 で API の破壊的変更があり Slack 通知ステップが失敗していました。v2 の入力形式に移行します。

## v1 → v2 API の変更点

| | v1 (`@v1.27.0`) | v2 (`@v2.1.1`) |
|---|---|---|
| チャンネル指定 | `channel-id` input | `payload` 内の `channel` |
| メッセージ | `slack-message` input | `payload` 内の `text` |
| トークン | `SLACK_BOT_TOKEN` env 変数 | `token` input |
| API メソッド | 暗黙的に推論 | `method: chat.postMessage` を明示的に指定 |

### Before (v1)
```yaml
- uses: slackapi/slack-github-action@v1.27.0
  with:
    channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
    slack-message: "メッセージ"
  env:
    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
```

### After (v2)
```yaml
- uses: slackapi/slack-github-action@v2.1.1
  with:
    method: chat.postMessage
    token: ${{ secrets.SLACK_BOT_TOKEN }}
    payload: |
      channel: ${{ secrets.SLACK_CHANNEL_ID }}
      text: "メッセージ"
```

## 変更内容

- 成功時の Slack 通知ステップを v2 API 形式に移行
- 失敗時の Slack エラー通知ステップを v2 API 形式に移行

## Test plan

- [ ] `workflow_dispatch` で手動実行し、Slack 通知が正常に送信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)