### PR TITLE
feat: thread投稿対応のため notion-post-fetcher / post-tweet-v2-action をアップデート

### DIFF
--- a/.github/workflows/xpost.yaml
+++ b/.github/workflows/xpost.yaml
@@ -15,7 +15,7 @@ jobs:
         run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Notion post fetcher
         id: notion-post-fetcher
-        uses: raycast-jp/notion-post-fetcher@v0.0.7
+        uses: raycast-jp/notion-post-fetcher@v0.1.0
         with:
           targetDate: ${{ env.CURRENT_DATE }}
           notion-token: ${{ secrets.NOTION_TOKEN }}
@@ -28,12 +28,22 @@ jobs:
         id: output-tweet-media
         run: |
           echo "Tweet Media: ${{ fromJson(steps.notion-post-fetcher.outputs.tweet).media }}"
+      - name: Print Output Thread Content
+        id: output-thread-content
+        run: |
+          echo "Thread Content: ${{ fromJson(steps.notion-post-fetcher.outputs.tweet).thread.content }}"
+      - name: Print Output Thread Media
+        id: output-thread-media
+        run: |
+          echo "Thread Media: ${{ fromJson(steps.notion-post-fetcher.outputs.tweet).thread.media }}"
       - name: Post tweet
         id: tweetx
-        uses: raycast-jp/post-tweet-v2-action@v0.1.2
+        uses: raycast-jp/post-tweet-v2-action@v0.2.0
         with:
           message: ${{ fromJson(steps.notion-post-fetcher.outputs.tweet).content }}
           media: ${{ fromJson(steps.notion-post-fetcher.outputs.tweet).media }}
+          thread-message: ${{ fromJson(steps.notion-post-fetcher.outputs.tweet).thread.content }}
+          thread-media: ${{ fromJson(steps.notion-post-fetcher.outputs.tweet).thread.media }}
           consumer-key: ${{ secrets.TWITTER_CONSUMER_KEY }}
           consumer-secret: ${{ secrets.TWITTER_CONSUMER_SECRET }}
           access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}


### PR DESCRIPTION
## 概要

スレッド投稿（リプライツイート）対応のため、関連する 2 つの action をアップデートします。

## 変更内容

- `raycast-jp/notion-post-fetcher` v0.0.7 → **v0.1.0**
  Notion DB の `スレッド投稿内容` / `スレッド画像` を読み取り、`tweet` output に `thread: { content, media? }` を含めるようになりました。
- `raycast-jp/post-tweet-v2-action` v0.1.2 → **v0.2.0**
  `thread-message` / `thread-media` 入力でメインツイートへリプライ投稿が可能になりました。
- `thread-message` / `thread-media` をワークフローへ追加
- デバッグ用に Thread Content / Thread Media を echo するステップを追加

## 互換性

- Notion DB に `スレッド投稿内容` 列が無い、または空の場合は `thread` フィールドが省略されるため、**従来の単発ツイート挙動と完全互換** です。
- スレッド投稿を有効化する場合は、Notion DB に下記プロパティを追加してください（任意）:
  | プロパティ名 | 型 | 用途 |
  | --- | --- | --- |
  | `スレッド投稿内容` | Rich Text | 返信ツイート本文 |
  | `スレッド画像` | Files | 返信ツイート画像 |

## 関連リンク

- raycast-jp/post-tweet-v2-action v0.2.0: https://github.com/raycast-jp/post-tweet-v2-action/releases/tag/v0.2.0
- raycast-jp/notion-post-fetcher v0.1.0: https://github.com/raycast-jp/notion-post-fetcher/releases/tag/v0.1.0
- 関連 issue (action 側 `bearer-token` の required 取り扱いについて): https://github.com/raycast-jp/post-tweet-v2-action/issues/87