### PR TITLE
feat: Add external dispatcher via Vercel Cron + PAT (temporary fix)

### DIFF
--- a/.github/workflows/xpost.yaml
+++ b/.github/workflows/xpost.yaml
@@ -1,6 +1,7 @@
 on:
-  schedule:
-    - cron: "21 10 * * *"
+  # NOTE: 一時的に Vercel Cron (PAT 経由の workflow_dispatch) から起動するためコメントアウト
+  # schedule:
+  #   - cron: "21 10 * * *"
   workflow_dispatch:
 
 jobs:

--- a/api/cron/xpost.js
+++ b/api/cron/xpost.js
@@ -11,7 +11,9 @@ const MAX_DELAY_MINUTES = Number(process.env.MAX_DELAY_MINUTES ?? 5);
 
 export default async function handler(req, res) {
   // Vercel Cron は CRON_SECRET を Authorization ヘッダーに付与して呼び出す
-  if (req.headers.authorization !== `Bearer ${process.env.CRON_SECRET}`) {
+  // CRON_SECRET 未設定時はフェイルクローズ（"Bearer undefined" での認証突破を防ぐ）
+  const secret = process.env.CRON_SECRET;
+  if (!secret || req.headers.authorization !== `Bearer ${secret}`) {
     return res.status(401).json({ error: "Unauthorized" });
   }
 

--- a/api/cron/xpost.js
+++ b/api/cron/xpost.js
@@ -1,0 +1,47 @@
+// 一時的な外部 cron ディスパッチャー。
+// Vercel Cron から呼び出され、GitHub PAT で xpost.yaml の workflow_dispatch を実行する。
+// TODO: GitHub App (feat/github-app-dispatcher) に移行したら PAT 認証を置き換える。
+
+const OWNER = "raycast-jp";
+const REPO = "automate-operations";
+const WORKFLOW = "xpost.yaml";
+const REF = "main";
+// NOTE: Function 内で sleep するため、maxDuration (vercel.json) を超えない値にすること
+const MAX_DELAY_MINUTES = Number(process.env.MAX_DELAY_MINUTES ?? 5);
+
+export default async function handler(req, res) {
+  // Vercel Cron は CRON_SECRET を Authorization ヘッダーに付与して呼び出す
+  if (req.headers.authorization !== `Bearer ${process.env.CRON_SECRET}`) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  // 投稿時刻をランダムにずらすため、dispatch 前に 0〜MAX_DELAY_MINUTES 分 sleep する
+  const delaySeconds = Math.floor(Math.random() * (MAX_DELAY_MINUTES * 60 + 1));
+  console.log(`Sleeping for ${delaySeconds} seconds before dispatch...`);
+  await new Promise((resolve) => setTimeout(resolve, delaySeconds * 1000));
+
+  const response = await fetch(
+    `https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${WORKFLOW}/dispatches`,
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${process.env.GITHUB_PAT}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ ref: REF }),
+    },
+  );
+
+  // workflow_dispatch 成功時は 204 No Content が返る
+  if (response.status !== 204) {
+    const body = await response.text();
+    console.error(`workflow_dispatch failed: ${response.status} ${body}`);
+    return res
+      .status(502)
+      .json({ error: `workflow_dispatch failed: ${response.status}`, body });
+  }
+
+  return res.status(200).json({ ok: true, dispatched: WORKFLOW, delaySeconds });
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "automate-operations-dispatcher",
+  "private": true,
+  "type": "module"
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/xpost",
+      "schedule": "21 10 * * *"
+    }
+  ],
+  "functions": {
+    "api/cron/xpost.js": {
+      "maxDuration": 360
+    }
+  }
+}


### PR DESCRIPTION
## 概要
GitHub Actionsのschedulesを実行時間の遅延を許容していたため、使用していたものの、最近かなり遅いので使用をやめたい。
GitHub Actions の \`schedule\` トリガーの代わりに、Vercel Cron から GitHub PAT 経由で \`workflow_dispatch\` を実行する外部ディスパッチャーを追加する

## 変更内容

- **\`api/cron/xpost.js\`** — Vercel Cron から呼ばれる Function。\`CRON_SECRET\` で認証し、0〜5分のランダム sleep 後に PAT で \`xpost.yaml\` の \`workflow_dispatch\` を実行
- **\`vercel.json\`** — cron 定義（毎日 10:21 UTC = 19:21 JST）と \`maxDuration: 360\`（sleep に耐えるためのタイムアウト延長）
- **\`package.json\`** — ESM 用の最小構成
- **\`.github/workflows/xpost.yaml\`** — \`schedule\` トリガーをコメントアウト（二重実行防止）

## 動作

毎日 **19:21〜19:26 JST のランダムな時刻**に投稿が実行される。

## デプロイに必要な設定（Vercel 側）

| 環境変数 | 内容 |
|---|---|
| \`GITHUB_PAT\` | Fine-grained PAT（このリポジトリのみ / Actions: Read and write） |
| \`CRON_SECRET\` | cron エンドポイントの認証用ランダム文字列 |
| \`MAX_DELAY_MINUTES\` | （任意）ランダム遅延の上限。デフォルト 5 |

## 備考

cloudflareとかvercelなどのworkflowに完全移行する予定だが一時的にこの対応とする
